### PR TITLE
Fixing Atlas bug with Message not showing

### DIFF
--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -57,10 +57,17 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
 - (void)expandPaginationWindow
 {
     self.expandingPaginationWindow = YES;
-    if (!self.queryController) return;
+    
+    if (!self.queryController) {
+        self.expandingPaginationWindow = NO;
+        return;
+    }
     
     BOOL moreMessagesAvailable = self.queryController.totalNumberOfObjects > ABS(self.queryController.paginationWindow);
-    if (!moreMessagesAvailable) return;
+    if (!moreMessagesAvailable) {
+        self.expandingPaginationWindow = NO;
+        return;
+    }
     
     NSUInteger numberOfMessagesToDisplay = MIN(-self.queryController.paginationWindow + ATLQueryControllerPaginationWindow, self.queryController.totalNumberOfObjects);
     self.queryController.paginationWindow = -numberOfMessagesToDisplay;


### PR DESCRIPTION
# STR
0) Go to a conversation with no chat
1) Type something into message bar
2) Scroll down and dismiss keyboard
3) Send message


Scrolling down calls `scrollViewDidEndDragging` which calls `configurePaginationWindow` which calls `expandPaginationWindow`. because we get YES for isExpandingPaginationWindow the the queryControllerDidChangeContentCall bail before it can configure the paginationWindow and the more message indicator